### PR TITLE
Removed sdk prod dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v0.14.0
+
+- removed symbol-sdk dependency
+
 # v0.13.0
 
 - upgraded symbol-sdk to v0.21.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,6 +227,7 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -268,6 +269,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -275,7 +277,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -286,17 +289,20 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
     },
     "backbone": {
       "version": "1.4.0",
@@ -325,6 +331,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       },
@@ -332,7 +339,8 @@
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
         }
       }
     },
@@ -383,7 +391,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -438,7 +447,8 @@
     "buffer-reverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
+      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A=",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -467,12 +477,14 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "catbuffer-typescript": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-0.0.22.tgz",
-      "integrity": "sha512-Wip3kJFnXrsMRF+4yJSE/F+aEqrTYLPPXdNuVftHNl9oFaKwQ9si8oI2ruSu53QIR+/ohOlY4QYtOagRpHnrFg=="
+      "integrity": "sha512-Wip3kJFnXrsMRF+4yJSE/F+aEqrTYLPPXdNuVftHNl9oFaKwQ9si8oI2ruSu53QIR+/ohOlY4QYtOagRpHnrFg==",
+      "dev": true
     },
     "chai": {
       "version": "4.2.0",
@@ -556,6 +568,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -598,7 +611,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coveralls": {
       "version": "3.0.11",
@@ -670,6 +684,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -701,7 +716,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -713,6 +729,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -768,22 +785,26 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -823,7 +844,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -845,7 +867,8 @@
     "futoin-hkdf": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz",
-      "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw=="
+      "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -863,6 +886,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -916,12 +940,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -998,6 +1024,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1040,7 +1067,8 @@
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1057,7 +1085,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1068,7 +1097,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -1184,12 +1214,14 @@
     "js-joda": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/js-joda/-/js-joda-1.11.0.tgz",
-      "integrity": "sha512-/HJpRhwP2fPyuSsCaZuoVJuaSIt8tUXykV4wOMRXrFk7RP9h9VWaFdS9YHKdMepxb/3TdXpL6IhfC9L0sqYVBw=="
+      "integrity": "sha512-/HJpRhwP2fPyuSsCaZuoVJuaSIt8tUXykV4wOMRXrFk7RP9h9VWaFdS9YHKdMepxb/3TdXpL6IhfC9L0sqYVBw==",
+      "dev": true
     },
     "js-sha256": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "dev": true
     },
     "js-sha3": {
       "version": "0.8.0",
@@ -1199,7 +1231,8 @@
     "js-sha512": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -1214,7 +1247,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -1225,17 +1259,20 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -1250,6 +1287,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -1314,7 +1352,8 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1384,12 +1423,14 @@
     "merkle-lib": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY=",
+      "dev": true
     },
     "merkletreejs": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.1.11.tgz",
       "integrity": "sha512-nJN3VIHeIAyB/PjO5Dj/Y0SEK7CGCCLD2IbV4el2kUIwlOtX3GOr5MwVO4EU+0AXvoDnJ0nmaLe5O86uIjWz/Q==",
+      "dev": true,
       "requires": {
         "buffer-reverse": "^1.0.1",
         "crypto-js": "^3.1.9-1",
@@ -1401,19 +1442,22 @@
         "crypto-js": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-          "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+          "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+          "dev": true
         }
       }
     },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -1440,7 +1484,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.4",
@@ -1531,7 +1576,8 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -1597,7 +1643,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -1734,7 +1781,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -1772,17 +1820,20 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -1835,6 +1886,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1862,6 +1914,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -1874,6 +1927,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.19"
       },
@@ -1881,7 +1935,8 @@
         "lodash": {
           "version": "4.17.20",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -1889,6 +1944,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
@@ -1967,7 +2023,8 @@
     "rxjs-compat": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.3.tgz",
-      "integrity": "sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw=="
+      "integrity": "sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.0",
@@ -1977,7 +2034,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -2079,6 +2137,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2094,14 +2153,16 @@
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
         }
       }
     },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string-width": {
       "version": "3.1.0",
@@ -2140,12 +2201,14 @@
     "symbol-openapi-typescript-fetch-client": {
       "version": "0.10.0-3",
       "resolved": "https://registry.npmjs.org/symbol-openapi-typescript-fetch-client/-/symbol-openapi-typescript-fetch-client-0.10.0-3.tgz",
-      "integrity": "sha512-cdRz7Nc/m2i7CC8wHtj//z5RxOKEKhS4l+fFQvh7YUlYcUPaHbgcq4RMXSZPmMJ4PnzocnqWpVKjMj5cTYgrPA=="
+      "integrity": "sha512-cdRz7Nc/m2i7CC8wHtj//z5RxOKEKhS4l+fFQvh7YUlYcUPaHbgcq4RMXSZPmMJ4PnzocnqWpVKjMj5cTYgrPA==",
+      "dev": true
     },
     "symbol-sdk": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-0.21.0.tgz",
       "integrity": "sha512-YFJ1PcVlFSivZe8RUOOGJJvXN2uleNTZB8ma6VONdz+obyI8QMAzdt4c6niyGTr76Md6dRQVJ/uaq+MpbJtDQg==",
+      "dev": true,
       "requires": {
         "bluebird": "^3.7.2",
         "catbuffer-typescript": "0.0.22",
@@ -2174,7 +2237,8 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         }
       }
     },
@@ -2222,6 +2286,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -2230,7 +2295,8 @@
     "treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
-      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
     },
     "ts-node": {
       "version": "7.0.1",
@@ -2342,6 +2408,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2461,6 +2528,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -2468,12 +2536,14 @@
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -2489,6 +2559,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -2581,7 +2652,8 @@
     "ws": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2016,6 +2016,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -2335,7 +2336,8 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
     },
     "tslint": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "create-hmac": "^1.1.7",
     "crypto-js": "^4.0.0",
     "js-sha3": "^0.8.0",
-    "rxjs": "^6.5.4",
     "tiny-secp256k1": "^1.1.3",
     "tweetnacl": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "bs58check": "^2.1.2",
     "create-hash": "^1.2.0",
     "create-hmac": "^1.1.7",
+    "crypto-js": "^4.0.0",
     "js-sha3": "^0.8.0",
-    "symbol-sdk": "^0.21.0",
     "rxjs": "^6.5.4",
     "tiny-secp256k1": "^1.1.3",
     "tweetnacl": "^1.0.3"
@@ -29,6 +29,7 @@
     "coveralls": "^3.0.9",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
+    "symbol-sdk": "^0.21.0",
     "ts-node": "^7.0.0",
     "tslint": "^6.0.0",
     "typedoc": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-hd-wallets",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Symbol library to handle hyper-deterministic wallets",
   "author": "Grégory Saive from Using Blockchain Ltd <greg@ubc.digital>",
   "main": "dist/index.js",

--- a/src/Cryptography.ts
+++ b/src/Cryptography.ts
@@ -19,9 +19,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {
-    SHA3Hasher as sha3Hasher,
-} from 'symbol-sdk';
 import { kmac256 } from 'js-sha3';
 const createHash = require('create-hash');
 const createHmac = require('create-hmac');
@@ -83,31 +80,5 @@ export class Cryptography {
     ): Buffer {
         const hex = kmac256(key, data, 512, publicSalt || '');
         return Buffer.from(hex, 'hex');
-    }
-
-    /**
-     * Calculates the hash of data.
-     * @param {Uint8Array} dest The computed hash destination.
-     * @param {Uint8Array} data The data to hash.
-     * @param {numeric} length The hash length in bytes.
-     */
-    public static sha3Hash(
-        dest: Uint8Array,
-        data: Uint8Array,
-        length: number = 64,
-    ): Uint8Array {
-        sha3Hasher.func(dest, data, length);
-        return dest;
-    }
-
-    /**
-     * Creates a SHA3 hasher object.
-     * @param {numeric} length The hash length in bytes.
-     * @returns {object} The hasher.
-     */
-    public static createSha3Hasher(
-        length: number = 64,
-    ): HasherInterface {
-        return sha3Hasher.createHasher(length);
     }
 }

--- a/src/MnemonicPassPhrase.ts
+++ b/src/MnemonicPassPhrase.ts
@@ -19,7 +19,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 import * as bip39 from 'bip39';
-import {Crypto} from 'symbol-sdk';
+import * as crypto from 'crypto';
 
 /**
  * Class `MnemonicPassPhrase` describes a mnemonic pass phrase generator
@@ -65,7 +65,7 @@ export class MnemonicPassPhrase {
      * @return  {Buffer}
      */
     public static CATAPULT_RNG = (bytes: number) => {
-        return Buffer.from(Crypto.randomBytes(bytes).buffer);
+        return Buffer.from(crypto.randomBytes(bytes).buffer);
     };
 
     /**

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -18,17 +18,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-import {
-    Account,
-    PublicAccount,
-    NetworkType,
-} from 'symbol-sdk';
 
 // internal dependencies
 import {
     ExtendedKey,
     KeyEncoding,
-    Network,
 } from '../index';
 
 /**
@@ -36,7 +30,7 @@ import {
  * produces _Catapult-ED25519_-compatible accounts.
  *
  * This class provides with a bridge between BIP32-ED25519 compatible
- * key pairs and the symbol-sdk `Account` or `PublicAccount` objects.
+ * key pairs and symbol ready private and public keys.
  *
  * @example Usage of hierarchical deterministic wallets
  *
@@ -45,13 +39,13 @@ import {
  * const wallet = new Wallet(xkey);
  *
  * // get master account
- * const masterAccount = wallet.getAccount();
+ * const masterAccount = wallet.getAccountPrivateKey();
  *
  * // get DEFAULT WALLET
- * const defaultWallet = wallet.getChildAccount();
+ * const defaultWallet = wallet.getChildAccountPrivateKey();
  *
  * // derive specific child path
- * const childWallet = wallet.getChildAccount('m/44\'/4343\'/0\'/0\'/0\'');
+ * const childWallet = wallet.getChildAccountPrivateKey('m/44\'/4343\'/0\'/0\'/0\'');
  * ```
  *
  * @see https://github.com/nemtech/NIP/issues/12
@@ -109,106 +103,82 @@ export class Wallet {
     }
 
     /**
-     * Get a symbol-sdk `Account` object with the extended
+     * Get a symbol private key string with the extended
      * key property.
      *
      * No derivation is done in this step. Derivation must be done either before
      * calling this method or using the `getChildAccount` method.
      *
-     * @param   networkType {NetworkType}   Which network type to use, defaults to MIJIN_TEST.
-     * @return  {Account}
-     * @throws  {Error}     On call of this method with a read-only wallet.
+     * @return  {string} main account private key.
+     * @throws  {Error}  On call of this method with a read-only wallet.
      */
-    getAccount(
-        networkType: NetworkType = NetworkType.MIJIN_TEST
-    ): Account {
+    getAccountPrivateKey(): string {
 
         // in case of read-only wallet, not possible to initiate Account
         // only PublicAccount can be used, see getPublicAccount().
         if (this.readOnly) {
-            throw new Error('Missing private key, please use method getPublicAccount().');
+            throw new Error('Missing private key, please use method getAccountPublicKey().');
         }
-
         // note: do not store private key in memory longer than function call
-        return Account.createFromPrivateKey(
-            this.extendedKey.getPrivateKey(KeyEncoding.ENC_HEX) as string,
-            networkType
-        );
+       return this.extendedKey.getPrivateKey(KeyEncoding.ENC_HEX) as string
+
     }
 
     /**
-     * Get a symbol-sdk `PublicAccount` object with the extended key property.
+     * Get a symbol public key string with the extended key property.
      *
      * No derivation is done in this step. Derivation must be done either before
      * calling this method or using the `getChildPublicAccount` method.
      *
-     * @param   networkType {NetworkType}   Which network type to use, defaults to MIJIN_TEST.
-     * @return  {PublicAccount}
+     * @return  {string} the account public key.
      */
-    getPublicAccount(
-        networkType: NetworkType = NetworkType.MIJIN_TEST
-    ): PublicAccount {
-
-        return PublicAccount.createFromPublicKey(
-            this.publicKey.toString('hex'),
-            networkType
-        );
+    getAccountPublicKey(): string {
+        return this.publicKey.toString('hex');
     }
 
     /**
-     * Get a symbol-sdk `Account` object with the derived child account.
+     * Get a symbol private key string with the derived child account.
      *
      * In case no derivation path is provided, the default wallet path
      * will be used, see `Wallet.DEFAULT_WALLET_PATH`.
      *
      * @see Wallet.DEFAULT_WALLET_PATH
      * @param   path        {string}        Child derivation path, default to `Wallet.DEFAULT_WALLET_PATH`.
-     * @param   networkType {NetworkType}   Which network type to use, defaults to MIJIN_TEST.
-     * @return  {Account | PublicAccount}
+     * @return  {string} the private key
      * @throws  {Error}     On call of this method with a read-only wallet.
      */
-    getChildAccount(
-        path: string = Wallet.DEFAULT_WALLET_PATH,
-        networkType: NetworkType = NetworkType.MIJIN_TEST
-    ): Account {
+    getChildAccountPrivateKey(
+        path: string = Wallet.DEFAULT_WALLET_PATH
+    ): string {
 
         // in case of read-only wallet, get PublicAccount instance
         if (this.readOnly) {
-            throw new Error('Missing private key, please use method getChildPublicAccount().');
+            throw new Error('Missing private key, please use method getChildAccountPublicKey().');
         }
 
         // child key derivation with `ExtendedKeyNode.derivePath()`
         const childKeyNode = this.extendedKey.derivePath(path);
 
         // non-read-only, get Account instance
-        return Account.createFromPrivateKey(
-            childKeyNode.getPrivateKey(KeyEncoding.ENC_HEX) as string,
-            networkType
-        );
+        return childKeyNode.getPrivateKey(KeyEncoding.ENC_HEX) as string;
     }
 
     /**
-     * Get a symbol-sdk `PublicAccount` object with the derived child account.
+     * Get a symbol public key with the derived child account.
      *
      * In case no derivation path is provided, the default wallet path
      * will be used, see `Wallet.DEFAULT_WALLET_PATH`.
      *
      * @see Wallet.DEFAULT_WALLET_PATH
      * @param   path        {string}        Child derivation path, default to `Wallet.DEFAULT_WALLET_PATH`.
-     * @param   networkType {NetworkType}   Which network type to use, defaults to MIJIN_TEST.
-     * @return  {Account | PublicAccount}
+     * @return string the child public key.
      */
-    getChildPublicAccount(
-        path: string = Wallet.DEFAULT_WALLET_PATH,
-        networkType: NetworkType = NetworkType.MIJIN_TEST
-    ): PublicAccount {
-
+    getChildAccountPublicKey(
+        path: string = Wallet.DEFAULT_WALLET_PATH
+    ): string {
         // child key derivation with `ExtendedKeyNode.derivePath()`
         const childKeyNode = this.extendedKey.derivePath(path);
-        return PublicAccount.createFromPublicKey(
-            childKeyNode.getPublicKey(KeyEncoding.ENC_HEX) as string,
-            networkType
-        );
+        return  childKeyNode.getPublicKey(KeyEncoding.ENC_HEX) as string;
     }
 
 }

--- a/test/Wallet.spec.ts
+++ b/test/Wallet.spec.ts
@@ -19,22 +19,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 import {expect} from 'chai';
-import {
-    Account,
-    NetworkType,
-    PublicAccount,
-} from 'symbol-sdk';
-
+import {Account, NetworkType, PublicAccount,} from 'symbol-sdk';
 // internal dependencies
-import {
-    CurveAlgorithm,
-    ExtendedKey,
-    KeyEncoding,
-    Network,
-    NodeInterface,
-    NodeEd25519,
-    Wallet,
-} from '../index';
+import {ExtendedKey, Network, Wallet,} from '../index';
+
+const networkType = NetworkType.MIJIN_TEST;
+
+function getChildAccount(wallet: Wallet, path: string = Wallet.DEFAULT_WALLET_PATH) {
+    return Account.createFromPrivateKey(wallet.getChildAccountPrivateKey(path), networkType)
+}
+
+function getAccount(wallet: Wallet) {
+    return Account.createFromPrivateKey(wallet.getAccountPrivateKey(), networkType)
+}
+
+function getPublicAccount(wallet: Wallet) {
+    return PublicAccount.createFromPublicKey(wallet.getAccountPublicKey(), networkType)
+}
+
+function getChildPublicAccount(wallet: Wallet, path: string = Wallet.DEFAULT_WALLET_PATH) {
+    return PublicAccount.createFromPublicKey(wallet.getChildAccountPublicKey(path), networkType)
+}
 
 describe('Wallet -->', () => {
 
@@ -73,7 +78,7 @@ describe('Wallet -->', () => {
         it('take extended key to create wallet and get correct private key', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getAccount();
+            const account = getAccount(wallet);
 
             expect(account.privateKey.toLowerCase()).to.be.equal(masterPriv);
         });
@@ -87,14 +92,14 @@ describe('Wallet -->', () => {
             const wallet = new Wallet(xpub);
 
             expect(() => {
-                wallet.getAccount();
-            }).to.throw('Missing private key, please use method getPublicAccount().');
+                getAccount(wallet);
+            }).to.throw('Missing private key, please use method getAccountPublicKey().');
         });
 
         it('get catapult compatible private key / public key pair (keypair)', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getAccount();
+            const account = getAccount(wallet);
 
             expect(account.privateKey.toLowerCase()).to.be.equal(masterPriv);
             expect(account.publicKey.toLowerCase()).to.be.equal(masterPub);
@@ -109,14 +114,14 @@ describe('Wallet -->', () => {
             const wallet = new Wallet(xpub);
 
             expect(() => {
-                wallet.getChildAccount();
-            }).to.throw('Missing private key, please use method getChildPublicAccount().');
+                getChildAccount(wallet);
+            }).to.throw('Missing private key, please use method getChildAccountPublicKey().');
         });
 
         it('derive default account when given no path', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getChildAccount();
+            const account = getChildAccount(wallet);
 
             expect(account.privateKey.toLowerCase()).to.be.equal(defaultPriv);
             expect(account.publicKey.toLowerCase()).to.be.equal(defaultPub);
@@ -125,7 +130,7 @@ describe('Wallet -->', () => {
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getChildAccount('m/44\'/4343\'/1\'/0\'/0\'');
+            const account = getChildAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 
             expect(account.privateKey.toLowerCase()).to.be.equal(secondPriv);
             expect(account.publicKey.toLowerCase()).to.be.equal(secondPub);
@@ -137,7 +142,7 @@ describe('Wallet -->', () => {
         it('get catapult compatible read-only account given extended private key', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getPublicAccount();
+            const account = getPublicAccount(wallet);
 
             expect(account).to.be.instanceof(PublicAccount);
             expect(account.publicKey.toLowerCase()).to.be.equal(masterPub);
@@ -147,7 +152,7 @@ describe('Wallet -->', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
-            const account = wallet.getPublicAccount();
+            const account = getPublicAccount(wallet);
 
             expect(account).to.be.instanceof(PublicAccount);
             expect(account.publicKey.toLowerCase()).to.be.equal(masterPub);
@@ -159,7 +164,7 @@ describe('Wallet -->', () => {
         it('derive default account when given no path', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getChildPublicAccount();
+            const account = getChildPublicAccount(wallet);
 
             expect(account).to.be.instanceof(PublicAccount);
             expect(account.publicKey.toLowerCase()).to.be.equal(defaultPub);
@@ -168,7 +173,7 @@ describe('Wallet -->', () => {
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
             const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
             const wallet = new Wallet(xkey);
-            const account = wallet.getChildPublicAccount('m/44\'/4343\'/1\'/0\'/0\'');
+            const account = getChildPublicAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 
             expect(account).to.be.instanceof(PublicAccount);
             expect(account.publicKey.toLowerCase()).to.be.equal(secondPub);


### PR DESCRIPTION
Hi @evias @rg911 

This PR removes the dependency of the library to the TS SDK. 
- The library is standalone, it doesn't need to be released just because there is an SDK update. You can see that the last releases are just to upgrade the SDK version. If we remove the SDK dependency, we only need to release when there is a feature change. Check out the https://github.com/nemtech/symbol-hd-wallets/blob/main/CHANGELOG.md
- Library could be used for similar problems not related to Symbol. One example could be a NIS1 Wallet if the plan is to improve the NIS apps.
- It simplifies the Wallet upgrade. Atm I want to test a new SDK in Wallet but I cannot because I need to upgrade the SDK dependencies from HD and QR (I'm doing QR next)
- It makes the library smaller, SDK is big
- The downside is the clients would need to generate Account and PublicAccount from the private and public key the project's Wallet returns. Not a big change at all.

Fixes https://github.com/nemtech/symbol-hd-wallets/issues/36