### PR TITLE
Default network removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const bip32Seed = mnemonic.toSeed();
 
 ```
 
-### Generating a HD wallet (CATAPULT **mijin** and **mijinTest** compatible)
+### Generating a HD wallet (SYMBOL **mijin** and **mijinTest** compatible)
 
 ```ts
 // examples/GeneratingAHDWalletPrivateNetworkCompatible.ts
@@ -103,7 +103,7 @@ import {ExtendedKey} from "../src/ExtendedKey";
 import {Wallet} from "../src/Wallet";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.MIJIN);
 const wallet = new Wallet(xkey);
 
 // get master account
@@ -124,7 +124,7 @@ const readOnlyDefaultAccount = readOnlyWallet.getChildPublicAccount();
 
 ```
 
-### Generating a HD wallet (CATAPULT **public** and **publicTest** compatible)
+### Generating a HD wallet (SYMBOL **public** and **publicTest** compatible)
 
 ```ts
 // examples/GeneratingAHDWalletPublicNetworkCompatible.ts
@@ -134,7 +134,7 @@ import {NetworkType} from "symbol-sdk";
 import {Wallet} from "../src/Wallet";
 import {ExtendedKey} from "../src/ExtendedKey";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT_PUBLIC);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // get master account
@@ -155,7 +155,7 @@ const readOnlyDefaultAccount = readOnlyWallet.getChildPublicAccount();
 
 ```
 
-### Signing with a HD wallet (CATAPULT compatible)
+### Signing with a HD wallet (SYMBOL compatible)
 
 ```ts
 // examples/SigningWithAHDWalletPrivateNetworkCompatible.ts
@@ -165,7 +165,7 @@ import {Wallet} from "../src/Wallet";
 import {ExtendedKey} from "../src/ExtendedKey";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT_PUBLIC);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // derive specific child path

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import {ExtendedKey} from "../src/ExtendedKey";
 import {Wallet} from "../src/Wallet";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.MIJIN);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // get master account

--- a/examples/GeneratingAHDWalletPrivateNetworkCompatible.ts
+++ b/examples/GeneratingAHDWalletPrivateNetworkCompatible.ts
@@ -3,7 +3,7 @@ import {ExtendedKey} from "../src/ExtendedKey";
 import {Wallet} from "../src/Wallet";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.MIJIN);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // get master account

--- a/examples/GeneratingAHDWalletPrivateNetworkCompatible.ts
+++ b/examples/GeneratingAHDWalletPrivateNetworkCompatible.ts
@@ -3,7 +3,7 @@ import {ExtendedKey} from "../src/ExtendedKey";
 import {Wallet} from "../src/Wallet";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.MIJIN);
 const wallet = new Wallet(xkey);
 
 // get master account

--- a/examples/GeneratingAHDWalletPublicNetworkCompatible.ts
+++ b/examples/GeneratingAHDWalletPublicNetworkCompatible.ts
@@ -3,7 +3,7 @@ import {NetworkType} from "symbol-sdk";
 import {Wallet} from "../src/Wallet";
 import {ExtendedKey} from "../src/ExtendedKey";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT_PUBLIC);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // get master account

--- a/examples/SigningWithAHDWalletPrivateNetworkCompatible.ts
+++ b/examples/SigningWithAHDWalletPrivateNetworkCompatible.ts
@@ -3,7 +3,7 @@ import {Wallet} from "../src/Wallet";
 import {ExtendedKey} from "../src/ExtendedKey";
 import {Network} from "../src/Network";
 
-const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.CATAPULT_PUBLIC);
+const xkey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.SYMBOL);
 const wallet = new Wallet(xkey);
 
 // derive specific child path

--- a/src/Compat/DeterministicKey.ts
+++ b/src/Compat/DeterministicKey.ts
@@ -44,7 +44,7 @@ export abstract class DeterministicKey implements NodeInterface {
      * @param ___D      {Buffer|undefined}  The private key of the node.
      * @param ___Q      {Buffer|undefined}  The public key of the node.
      * @param chainCode {Buffer}            The chain code of the node (32 bytes).
-     * @param network   {Network}           The network of the node, defaults to `Network.CATAPULT`.
+     * @param network   {Network}           The network of the node
      * @param ___DEPTH  {number}            The depth of the node (0 for master).
      * @param ___INDEX  {number}            The account index (0 for master).
      * @param ___PARENT_FINGERPRINT     {number}    The parent fingerprint (0x00000000 for master)
@@ -53,7 +53,7 @@ export abstract class DeterministicKey implements NodeInterface {
         private readonly __D: Buffer | undefined, // private Key
         private __Q: Buffer | undefined, // public Key
         public readonly chainCode: Buffer,
-        public readonly network: Network = Network.CATAPULT,
+        public readonly network: Network,
         private readonly __DEPTH: number = 0,
         private readonly __INDEX: number = 0,
         private readonly __PARENT_FINGERPRINT: number = 0x00000000,
@@ -383,6 +383,6 @@ export abstract class DeterministicKey implements NodeInterface {
 
     // XXX hidden usage of toHex() ?
     public toWIF(): string {
-        throw new TypeError('Catapult BIP32 keys cannot be converted to WIF. Please use the toHex() method.');
+        throw new TypeError('Symbol BIP32 keys cannot be converted to WIF. Please use the toHex() method.');
     }
 }

--- a/src/Curves/NodeEd25519.ts
+++ b/src/Curves/NodeEd25519.ts
@@ -101,7 +101,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
      *
      * Depending on the curve algorithm, the seed is prepended with one of:
      *
-     * - `ed25519 seed` for ed25519[-sha512] implementation (Network.CATAPULT|Network.CATAPULT_PUBLIC)
+     * - `ed25519 seed` for ed25519[-sha512] implementation (Network.MIJIN|Network.SYMBOL)
      *
      * @see https://github.com/bitcoinjs/bip32/blob/master/src/bip32.js#L258
      * @param   seed    {Buffer}
@@ -110,7 +110,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
      */
     public static fromSeed(
         seed: Buffer,
-        network: Network = Network.CATAPULT,
+        network: Network,
         macType: MACType = MACType.HMAC
     ): NodeEd25519 {
 
@@ -118,7 +118,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
         if (seed.length > 64) throw new TypeError('Seed should be at most 512 bits');
 
         // (1) depending on curve algorithm, prepend the seed with one of:
-        // `ed25519 seed` for ed25519[-sha512] implementation (Network.CATAPULT|Network.CATAPULT_PUBLIC)
+        // `ed25519 seed` for ed25519[-sha512] implementation (Network.MIJIN|Network.SYMBOL)
         const prefix = 'ed25519 seed';
         const I = MACImpl.create(macType, Buffer.from(prefix, 'utf8'), seed);
 
@@ -142,12 +142,12 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
      *
      * @see https://github.com/bitcoinjs/bip32/blob/master/ts-src/bip32.ts#L286
      * @param   inString    {string}    The base58 payload of the extended key.
-     * @param   network     {Network}   (Optional) The network of the key, default to `Network.CATAPULT`.
+     * @param   network     {Network}   (Optional) The network of the key.
      * @return  {NodeEd25519}
      */
     public static fromBase58(
         inString: string,
-        network: Network = Network.CATAPULT,
+        network: Network,
     ): NodeEd25519 {
 
         // decode base58
@@ -158,10 +158,10 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
 
         // 4 bytes: version bytes
         const version = buffer.readUInt32BE(0);
-        if (version !== Network.CATAPULT.privateKeyPrefix
-         && version !== Network.CATAPULT.publicKeyPrefix) {
-            throw new TypeError('Payload Version must be one of: ' + Network.CATAPULT.privateKeyPrefix
-                              + ' or ' + Network.CATAPULT.publicKeyPrefix + '.');
+        if (version !== Network.MIJIN.privateKeyPrefix
+         && version !== Network.MIJIN.publicKeyPrefix) {
+            throw new TypeError('Payload Version must be one of: ' + Network.MIJIN.privateKeyPrefix
+                              + ' or ' + Network.MIJIN.publicKeyPrefix + '.');
         }
 
         // 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 descendants, ...
@@ -188,7 +188,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
         const chainCode = buffer.slice(13, 45);
         let hd: NodeEd25519;
 
-        if (version === Network.CATAPULT.privateKeyPrefix) {
+        if (version === Network.MIJIN.privateKeyPrefix) {
         // 33 bytes: private key data (0x00 + k)
 
             if (buffer.readUInt8(45) !== 0x00) {

--- a/src/Curves/NodeEd25519.ts
+++ b/src/Curves/NodeEd25519.ts
@@ -101,7 +101,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
      *
      * Depending on the curve algorithm, the seed is prepended with one of:
      *
-     * - `ed25519 seed` for ed25519[-sha512] implementation (Network.MIJIN|Network.SYMBOL)
+     * - `ed25519 seed` for ed25519[-sha512] implementation (Network.SYMBOL)
      *
      * @see https://github.com/bitcoinjs/bip32/blob/master/src/bip32.js#L258
      * @param   seed    {Buffer}
@@ -118,7 +118,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
         if (seed.length > 64) throw new TypeError('Seed should be at most 512 bits');
 
         // (1) depending on curve algorithm, prepend the seed with one of:
-        // `ed25519 seed` for ed25519[-sha512] implementation (Network.MIJIN|Network.SYMBOL)
+        // `ed25519 seed` for ed25519[-sha512] implementation (Network.SYMBOL)
         const prefix = 'ed25519 seed';
         const I = MACImpl.create(macType, Buffer.from(prefix, 'utf8'), seed);
 
@@ -158,10 +158,10 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
 
         // 4 bytes: version bytes
         const version = buffer.readUInt32BE(0);
-        if (version !== Network.MIJIN.privateKeyPrefix
-         && version !== Network.MIJIN.publicKeyPrefix) {
-            throw new TypeError('Payload Version must be one of: ' + Network.MIJIN.privateKeyPrefix
-                              + ' or ' + Network.MIJIN.publicKeyPrefix + '.');
+        if (version !== Network.SYMBOL.privateKeyPrefix
+         && version !== Network.SYMBOL.publicKeyPrefix) {
+            throw new TypeError('Payload Version must be one of: ' + Network.SYMBOL.privateKeyPrefix
+                              + ' or ' + Network.SYMBOL.publicKeyPrefix + '.');
         }
 
         // 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 descendants, ...
@@ -188,7 +188,7 @@ export class NodeEd25519 extends DeterministicKey implements NodeInterface {
         const chainCode = buffer.slice(13, 45);
         let hd: NodeEd25519;
 
-        if (version === Network.MIJIN.privateKeyPrefix) {
+        if (version === Network.SYMBOL.privateKeyPrefix) {
         // 33 bytes: private key data (0x00 + k)
 
             if (buffer.readUInt8(45) !== 0x00) {

--- a/src/ExtendedKey.ts
+++ b/src/ExtendedKey.ts
@@ -94,11 +94,11 @@ export class ExtendedKey {
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 
-        if (network === Network.CATAPULT || network === Network.CATAPULT_PUBLIC) {
+        if (network === Network.MIJIN || network === Network.SYMBOL) {
         // use NodeEd25519 node implementation
 
             // interpret payload
-            const ed25519Node = NodeEd25519.fromBase58(payload);
+            const ed25519Node = NodeEd25519.fromBase58(payload, network);
 
             // instanciate our ExtendedKey
             return new ExtendedKey(ed25519Node, network, macType);
@@ -136,7 +136,7 @@ export class ExtendedKey {
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 
-        if (network === Network.CATAPULT || network === Network.CATAPULT_PUBLIC) {
+        if (network === Network.MIJIN || network === Network.SYMBOL) {
         // use NodeEd25519 node implementation
 
             // use hexadecimal seed

--- a/src/ExtendedKey.ts
+++ b/src/ExtendedKey.ts
@@ -67,7 +67,7 @@ export class ExtendedKey {
                  * The hyper-deterministic node network.
                  * @var {Network}
                  */
-                public network: Network = Network.BITCOIN,
+                public network: Network,
                 /**
                  * The Message Authentication Code type to use.
                  * Possible values include HMAC and KMAC.
@@ -90,7 +90,7 @@ export class ExtendedKey {
      */
     public static createFromBase58(
         payload: string,
-        network: Network = Network.BITCOIN,
+        network: Network,
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 
@@ -132,7 +132,7 @@ export class ExtendedKey {
      */
     public static createFromSeed(
         seed: string,
-        network: Network = Network.BITCOIN,
+        network: Network,
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 

--- a/src/ExtendedKey.ts
+++ b/src/ExtendedKey.ts
@@ -94,7 +94,7 @@ export class ExtendedKey {
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 
-        if (network === Network.MIJIN || network === Network.SYMBOL) {
+        if (network === Network.SYMBOL || network === Network.SYMBOL) {
         // use NodeEd25519 node implementation
 
             // interpret payload
@@ -136,7 +136,7 @@ export class ExtendedKey {
         macType: MACType = MACType.HMAC
     ): ExtendedKey {
 
-        if (network === Network.MIJIN || network === Network.SYMBOL) {
+        if (network === Network.SYMBOL || network === Network.SYMBOL) {
         // use NodeEd25519 node implementation
 
             // use hexadecimal seed

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -57,19 +57,6 @@ export class Network {
     );
 
     /**
-     * CATAPULT protocol extended key prefixes
-     *
-     * Result in Base58 notation to `xpub` and `xprv`.
-     *
-     * @var {Network}
-     */
-    public static readonly MIJIN: Network = new Network(
-        0x0488b21e, // base58 'xpub'
-        0x0488ade4, // base58 'xprv'
-        CurveAlgorithm.ed25519
-    );
-
-    /**
      * SYMBOL public network protocol extended key prefixes
      *
      * Result in Base58 notation to `xpub` and `xprv`.

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -63,20 +63,20 @@ export class Network {
      *
      * @var {Network}
      */
-    public static readonly CATAPULT: Network = new Network(
+    public static readonly MIJIN: Network = new Network(
         0x0488b21e, // base58 'xpub'
         0x0488ade4, // base58 'xprv'
         CurveAlgorithm.ed25519
     );
 
     /**
-     * CATAPULT public network protocol extended key prefixes
+     * SYMBOL public network protocol extended key prefixes
      *
      * Result in Base58 notation to `xpub` and `xprv`.
      *
      * @var {Network}
      */
-    public static readonly CATAPULT_PUBLIC: Network = new Network(
+    public static readonly SYMBOL: Network = new Network(
         0x0488b21e, // base58 'xpub'
         0x0488ade4, // base58 'xprv'
         CurveAlgorithm.ed25519

--- a/test/CompatibilityBIP32.spec.ts
+++ b/test/CompatibilityBIP32.spec.ts
@@ -18,22 +18,21 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-import {expect} from 'chai';
-import * as bip32 from 'bip32';
-
+import { expect } from 'chai';
 // internal dependencies
 import {
-    ExtendedKey,
-    KeyEncoding
+    ExtendedKey
 } from '../index';
+import { Network } from '../src/Network';
+
 
 describe('BIP32 Compatibility -->', () => {
 
     describe('ExtendedKey should', () => {
-        it ('throw for hardened derivation with extended public key', () => {
+        it('throw for hardened derivation with extended public key', () => {
             expect(() => {
                 // create master key node
-                const masterKey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f');
+                const masterKey = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f', Network.BITCOIN);
                 const masterPub = masterKey.getPublicNode();
 
                 // use hardened path to produce error because `masterPub` is neutered
@@ -41,17 +40,17 @@ describe('BIP32 Compatibility -->', () => {
             }).to.throw('Missing private key for hardened child key');
         });
 
-        it ('throw given seed length smaller than 16 (seed of 8 bytes)', () => {
+        it('throw given seed length smaller than 16 (seed of 8 bytes)', () => {
             expect(() => {
                 // create master key node
-                const ignored = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f'.substr(0, 16));
+                const ignored = ExtendedKey.createFromSeed('000102030405060708090a0b0c0d0e0f'.substr(0, 16), Network.BITCOIN);
             }).to.throw('Seed should be at least 128 bits');
         });
 
-        it ('throw given seed length bigger than 64 (seed of 96 bytes)', () => {
+        it('throw given seed length bigger than 64 (seed of 96 bytes)', () => {
             expect(() => {
                 // create master key node
-                const ignored = ExtendedKey.createFromSeed('00'.repeat(96));
+                const ignored = ExtendedKey.createFromSeed('00'.repeat(96), Network.BITCOIN);
             }).to.throw('Seed should be at most 512 bits');
         });
     });

--- a/test/DerivationBIP32.spec.ts
+++ b/test/DerivationBIP32.spec.ts
@@ -18,14 +18,13 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-import {expect} from 'chai';
-import * as bip32 from 'bip32';
-
+import { expect } from 'chai';
 // internal dependencies
 import {
-    ExtendedKey,
-    KeyEncoding
+    ExtendedKey
 } from '../index';
+import { Network } from '../src/Network';
+
 
 describe('BIP32 Extended Keys -->', () => {
 
@@ -112,7 +111,7 @@ describe('BIP32 Extended Keys -->', () => {
     describe('BIP32 ExtendedKey should', () => {
         extendedKeys.map((extendedKey) => {
             // create master key node
-            const masterKey = ExtendedKey.createFromSeed(extendedKey.seedHex);
+            const masterKey = ExtendedKey.createFromSeed(extendedKey.seedHex, Network.BITCOIN);
 
             it (extendedKey.label + ': create correct master extended private key', () => {
                 expect(masterKey.toBase58()).to.be.equal(extendedKey.masterPrv);

--- a/test/DerivationEd25519.spec.ts
+++ b/test/DerivationEd25519.spec.ts
@@ -151,7 +151,7 @@ describe('BIP32-Ed15519 Extended Keys -->', () => {
             // create master key node
             const masterKey = ExtendedKey.createFromSeed(
                 extendedKey.seedHex,
-                Network.CATAPULT
+                Network.MIJIN
             );
 
             it (extendedKey.label + ': create correct master extended private key', () => {
@@ -200,7 +200,7 @@ describe('BIP32-Ed15519 Extended Keys -->', () => {
             const expectPublicKey = '2e834140fd66cf87b254a693a2c7862c819217b676d3943267156625e816ec6f';
 
             const privateBytes = Convert.hexToUint8(privateKey);
-            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.CATAPULT);
+            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.MIJIN);
 
             expect(node.publicKey.toString('hex')).to.equal(expectPublicKey);
         });
@@ -211,7 +211,7 @@ describe('BIP32-Ed15519 Extended Keys -->', () => {
 
             // REVERSED private key (NIS)
             const privateBytes = Convert.hexToUint8Reverse(privateKey);
-            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.CATAPULT_PUBLIC);
+            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.SYMBOL);
 
             expect(node.publicKey.toString('hex')).to.equal(expectPublicKey);
         });

--- a/test/DerivationEd25519.spec.ts
+++ b/test/DerivationEd25519.spec.ts
@@ -151,7 +151,7 @@ describe('BIP32-Ed15519 Extended Keys -->', () => {
             // create master key node
             const masterKey = ExtendedKey.createFromSeed(
                 extendedKey.seedHex,
-                Network.MIJIN
+                Network.SYMBOL
             );
 
             it (extendedKey.label + ': create correct master extended private key', () => {
@@ -200,7 +200,7 @@ describe('BIP32-Ed15519 Extended Keys -->', () => {
             const expectPublicKey = '2e834140fd66cf87b254a693a2c7862c819217b676d3943267156625e816ec6f';
 
             const privateBytes = Convert.hexToUint8(privateKey);
-            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.MIJIN);
+            const node = new NodeEd25519(Buffer.from(privateBytes), undefined, Buffer.from(''), Network.SYMBOL);
 
             expect(node.publicKey.toString('hex')).to.equal(expectPublicKey);
         });

--- a/test/DerivationKMAC.spec.ts
+++ b/test/DerivationKMAC.spec.ts
@@ -90,12 +90,12 @@ describe('BIP32-Ed15519 KMAC derivation -->', () => {
     // create HMAC and KMAC master keys
     const HMACMasterKey = ExtendedKey.createFromSeed(
         seed,
-        Network.MIJIN
+        Network.SYMBOL
     );
 
     const KMACMasterKey = ExtendedKey.createFromSeed(
         seed,
-        Network.MIJIN,
+        Network.SYMBOL,
         MACType.KMAC
     );
 

--- a/test/DerivationKMAC.spec.ts
+++ b/test/DerivationKMAC.spec.ts
@@ -90,12 +90,12 @@ describe('BIP32-Ed15519 KMAC derivation -->', () => {
     // create HMAC and KMAC master keys
     const HMACMasterKey = ExtendedKey.createFromSeed(
         seed,
-        Network.CATAPULT
+        Network.MIJIN
     );
 
     const KMACMasterKey = ExtendedKey.createFromSeed(
         seed,
-        Network.CATAPULT,
+        Network.MIJIN,
         MACType.KMAC
     );
 

--- a/test/ExtendedKey.spec.ts
+++ b/test/ExtendedKey.spec.ts
@@ -81,9 +81,9 @@ describe('ExtendedKey -->', () => {
             expect(node.chainCode).to.not.be.undefined;
         });
 
-        it('should create NodeEd25519 node object given Network.CATAPULT', () => {
-            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.CATAPULT);
-            const neuteredMaster = new ExtendedKey(node, Network.CATAPULT);
+        it('should create NodeEd25519 node object given Network.MIJIN', () => {
+            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.MIJIN);
+            const neuteredMaster = new ExtendedKey(node, Network.MIJIN);
             const nodeEd25519 = neuteredMaster.node as NodeEd25519;
 
             expect(nodeEd25519).to.be.instanceof(NodeEd25519);
@@ -91,9 +91,9 @@ describe('ExtendedKey -->', () => {
             expect(nodeEd25519.network.curve).to.be.equal(CurveAlgorithm.ed25519);
         });
 
-        it('should create NodeEd25519 node object given Network.CATAPULT_PUBLIC', () => {
-            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.CATAPULT_PUBLIC);
-            const neuteredMaster = new ExtendedKey(node, Network.CATAPULT_PUBLIC);
+        it('should create NodeEd25519 node object given Network.SYMBOL', () => {
+            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.SYMBOL);
+            const neuteredMaster = new ExtendedKey(node, Network.SYMBOL);
             const nodeEd25519 = neuteredMaster.node as NodeEd25519;
 
             expect(nodeEd25519).to.be.instanceof(NodeEd25519);
@@ -145,24 +145,24 @@ describe('ExtendedKey -->', () => {
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.secp256k1);
         });
 
-        it('use network given network Network.CATAPULT', () => {
-            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.CATAPULT);
+        it('use network given network Network.MIJIN', () => {
+            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.MIJIN);
 
-            // check that Network.CATAPULT was used correctly
-            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.CATAPULT.privateKeyPrefix);
-            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.CATAPULT.publicKeyPrefix);
+            // check that Network.MIJIN was used correctly
+            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
+            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
             expect(neuteredNode.node).to.be.instanceof(NodeEd25519);
         });
 
-        it('use network given network Network.CATAPULT_PUBLIC', () => {
-            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.CATAPULT_PUBLIC);
+        it('use network given network Network.SYMBOL', () => {
+            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.SYMBOL);
 
-            // check that Network.CATAPULT was used correctly
-            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.CATAPULT_PUBLIC.privateKeyPrefix);
-            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.CATAPULT_PUBLIC.publicKeyPrefix);
+            // check that Network.MIJIN was used correctly
+            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
+            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -190,24 +190,24 @@ describe('ExtendedKey -->', () => {
             expect(masterFromSeed.toBase58()).to.be.equals(extendedKeys.nonNeutered[0].key);
         });
 
-        it('use network given network Network.CATAPULT', () => {
-            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.CATAPULT);
+        it('use network given network Network.MIJIN', () => {
+            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.MIJIN);
 
-            // check that Network.CATAPULT was used correctly
-            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.CATAPULT.privateKeyPrefix);
-            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.CATAPULT.publicKeyPrefix);
+            // check that Network.MIJIN was used correctly
+            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
+            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
             expect(masterFromSeed.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
             expect(masterFromSeed.node).to.be.instanceof(NodeEd25519);
         });
 
-        it('use network given network Network.CATAPULT_PUBLIC', () => {
-            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.CATAPULT_PUBLIC);
+        it('use network given network Network.SYMBOL', () => {
+            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.SYMBOL);
 
-            // check that Network.CATAPULT was used correctly
-            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.CATAPULT_PUBLIC.privateKeyPrefix);
-            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.CATAPULT_PUBLIC.publicKeyPrefix);
+            // check that Network.MIJIN was used correctly
+            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
+            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(masterFromSeed.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -231,13 +231,13 @@ describe('ExtendedKey -->', () => {
         });
 
         it('use correct network after being neutered', () => {
-            const node = NodeEd25519.fromBase58(extendedKeys.neutered[1].key);
-            const neuteredMaster = new ExtendedKey(node, Network.CATAPULT);
+            const node = NodeEd25519.fromBase58(extendedKeys.neutered[1].key, Network.MIJIN);
+            const neuteredMaster = new ExtendedKey(node, Network.MIJIN);
             const publicNode = neuteredMaster.getPublicNode();
 
-            // check that Network.CATAPULT was used correctly
-            expect(publicNode.network.privateKeyPrefix).to.be.equal(Network.CATAPULT.privateKeyPrefix);
-            expect(publicNode.network.publicKeyPrefix).to.be.equal(Network.CATAPULT.publicKeyPrefix);
+            // check that Network.MIJIN was used correctly
+            expect(publicNode.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
+            expect(publicNode.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
             expect(publicNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -365,18 +365,18 @@ describe('ExtendedKey -->', () => {
             // http://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=tests/t-ed25519.inp
             vectorED25519.map(vec => {
                 const privateKey = Buffer.from(Convert.hexToUint8(vec.sk));
-                const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.CATAPULT);
+                const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.MIJIN);
 
                 expect(bip32Node.privateKey.toString('hex')).to.be.equal(vec.sk);
                 expect(bip32Node.publicKey.toString('hex')).to.be.equal(vec.pk);
             })
         })
 
-        it('produce SHA512 public key given Network.CATAPULT', () => {
+        it('produce SHA512 public key given Network.MIJIN', () => {
             const privateHex = '575dbb3062267eff57c970a336ebbc8fbcfe12c5bd3ed7bc11eb0481d7704ced';
             const expectPub = '2e834140fd66cf87b254a693a2c7862c819217b676d3943267156625e816ec6f';
             const privateKey = Buffer.from(Convert.hexToUint8(privateHex));
-            const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.CATAPULT);
+            const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.MIJIN);
 
             expect(bip32Node.privateKey.toString('hex')).to.be.equal(privateHex);
             expect(bip32Node.publicKey.toString('hex')).to.be.equal(expectPub);
@@ -388,7 +388,7 @@ describe('ExtendedKey -->', () => {
 
             // NIS compatibility requires "key reversal".
             const reversedKey = Buffer.from(Convert.hexToUint8Reverse(privateHex));
-            const bip32Node = new NodeEd25519(reversedKey, undefined, Buffer.from(''), Network.CATAPULT_PUBLIC);
+            const bip32Node = new NodeEd25519(reversedKey, undefined, Buffer.from(''), Network.SYMBOL);
 
             expect(bip32Node.privateKey.toString('hex')).to.be.equal(reversedKey.toString('hex'));
             expect(bip32Node.publicKey.toString('hex')).to.be.equal(expectPub);

--- a/test/ExtendedKey.spec.ts
+++ b/test/ExtendedKey.spec.ts
@@ -81,9 +81,9 @@ describe('ExtendedKey -->', () => {
             expect(node.chainCode).to.not.be.undefined;
         });
 
-        it('should create NodeEd25519 node object given Network.MIJIN', () => {
-            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.MIJIN);
-            const neuteredMaster = new ExtendedKey(node, Network.MIJIN);
+        it('should create NodeEd25519 node object given Network.SYMBOL', () => {
+            const node = NodeEd25519.fromBase58(extendedKeys.neutered[0].key, Network.SYMBOL);
+            const neuteredMaster = new ExtendedKey(node, Network.SYMBOL);
             const nodeEd25519 = neuteredMaster.node as NodeEd25519;
 
             expect(nodeEd25519).to.be.instanceof(NodeEd25519);
@@ -145,12 +145,12 @@ describe('ExtendedKey -->', () => {
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.secp256k1);
         });
 
-        it('use network given network Network.MIJIN', () => {
-            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.MIJIN);
+        it('use network given network Network.SYMBOL', () => {
+            const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.SYMBOL);
 
-            // check that Network.MIJIN was used correctly
-            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
-            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
+            // check that Network.SYMBOL was used correctly
+            expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
+            expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -160,7 +160,7 @@ describe('ExtendedKey -->', () => {
         it('use network given network Network.SYMBOL', () => {
             const neuteredNode = ExtendedKey.createFromBase58(extendedKeys.neutered[0].key, Network.SYMBOL);
 
-            // check that Network.MIJIN was used correctly
+            // check that Network.SYMBOL was used correctly
             expect(neuteredNode.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
             expect(neuteredNode.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(neuteredNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
@@ -190,12 +190,12 @@ describe('ExtendedKey -->', () => {
             expect(masterFromSeed.toBase58()).to.be.equals(extendedKeys.nonNeutered[0].key);
         });
 
-        it('use network given network Network.MIJIN', () => {
-            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.MIJIN);
+        it('use network given network Network.SYMBOL', () => {
+            const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.SYMBOL);
 
-            // check that Network.MIJIN was used correctly
-            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
-            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
+            // check that Network.SYMBOL was used correctly
+            expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
+            expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(masterFromSeed.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -205,7 +205,7 @@ describe('ExtendedKey -->', () => {
         it('use network given network Network.SYMBOL', () => {
             const masterFromSeed = ExtendedKey.createFromSeed(extendedKeys.seedHex, Network.SYMBOL);
 
-            // check that Network.MIJIN was used correctly
+            // check that Network.SYMBOL was used correctly
             expect(masterFromSeed.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
             expect(masterFromSeed.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(masterFromSeed.network.curve).to.be.equal(CurveAlgorithm.ed25519);
@@ -231,13 +231,13 @@ describe('ExtendedKey -->', () => {
         });
 
         it('use correct network after being neutered', () => {
-            const node = NodeEd25519.fromBase58(extendedKeys.neutered[1].key, Network.MIJIN);
-            const neuteredMaster = new ExtendedKey(node, Network.MIJIN);
+            const node = NodeEd25519.fromBase58(extendedKeys.neutered[1].key, Network.SYMBOL);
+            const neuteredMaster = new ExtendedKey(node, Network.SYMBOL);
             const publicNode = neuteredMaster.getPublicNode();
 
-            // check that Network.MIJIN was used correctly
-            expect(publicNode.network.privateKeyPrefix).to.be.equal(Network.MIJIN.privateKeyPrefix);
-            expect(publicNode.network.publicKeyPrefix).to.be.equal(Network.MIJIN.publicKeyPrefix);
+            // check that Network.SYMBOL was used correctly
+            expect(publicNode.network.privateKeyPrefix).to.be.equal(Network.SYMBOL.privateKeyPrefix);
+            expect(publicNode.network.publicKeyPrefix).to.be.equal(Network.SYMBOL.publicKeyPrefix);
             expect(publicNode.network.curve).to.be.equal(CurveAlgorithm.ed25519);
 
             // also check node implementation that was used
@@ -365,18 +365,18 @@ describe('ExtendedKey -->', () => {
             // http://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=tests/t-ed25519.inp
             vectorED25519.map(vec => {
                 const privateKey = Buffer.from(Convert.hexToUint8(vec.sk));
-                const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.MIJIN);
+                const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.SYMBOL);
 
                 expect(bip32Node.privateKey.toString('hex')).to.be.equal(vec.sk);
                 expect(bip32Node.publicKey.toString('hex')).to.be.equal(vec.pk);
             })
         })
 
-        it('produce SHA512 public key given Network.MIJIN', () => {
+        it('produce SHA512 public key given Network.SYMBOL', () => {
             const privateHex = '575dbb3062267eff57c970a336ebbc8fbcfe12c5bd3ed7bc11eb0481d7704ced';
             const expectPub = '2e834140fd66cf87b254a693a2c7862c819217b676d3943267156625e816ec6f';
             const privateKey = Buffer.from(Convert.hexToUint8(privateHex));
-            const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.MIJIN);
+            const bip32Node = new NodeEd25519(privateKey, undefined, Buffer.from(''), Network.SYMBOL);
 
             expect(bip32Node.privateKey.toString('hex')).to.be.equal(privateHex);
             expect(bip32Node.publicKey.toString('hex')).to.be.equal(expectPub);

--- a/test/Wallet.spec.ts
+++ b/test/Wallet.spec.ts
@@ -61,14 +61,14 @@ describe('Wallet -->', () => {
     describe('constructor should', () => {
 
         it('take extended key and set read-only to false when non-neutered', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
 
             expect(wallet.isReadOnly()).to.be.equal(false);
         });
 
         it('take extended key and set read-only to true when neutered', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -76,7 +76,7 @@ describe('Wallet -->', () => {
         });
 
         it('take extended key to create wallet and get correct private key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getAccount(wallet);
 
@@ -87,7 +87,7 @@ describe('Wallet -->', () => {
     describe('getAccount() should', () => {
 
         it('throw when wallet initialized with extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -97,7 +97,7 @@ describe('Wallet -->', () => {
         });
 
         it('get catapult compatible private key / public key pair (keypair)', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getAccount(wallet);
 
@@ -109,7 +109,7 @@ describe('Wallet -->', () => {
     describe('getChildAccount() should', () => {
 
         it('throw when wallet initialized with extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -119,7 +119,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive default account when given no path', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getChildAccount(wallet);
 
@@ -128,7 +128,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getChildAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 
@@ -140,7 +140,7 @@ describe('Wallet -->', () => {
     describe('getPublicAccount() should', () => {
 
         it('get catapult compatible read-only account given extended private key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getPublicAccount(wallet);
 
@@ -149,7 +149,7 @@ describe('Wallet -->', () => {
         });
 
         it('get catapult compatible read-only account given extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
             const account = getPublicAccount(wallet);
@@ -162,7 +162,7 @@ describe('Wallet -->', () => {
     describe('getChildPublicAccount() should', () => {
 
         it('derive default account when given no path', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getChildPublicAccount(wallet);
 
@@ -171,7 +171,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.SYMBOL);
             const wallet = new Wallet(xkey);
             const account = getChildPublicAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 

--- a/test/Wallet.spec.ts
+++ b/test/Wallet.spec.ts
@@ -61,14 +61,14 @@ describe('Wallet -->', () => {
     describe('constructor should', () => {
 
         it('take extended key and set read-only to false when non-neutered', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
 
             expect(wallet.isReadOnly()).to.be.equal(false);
         });
 
         it('take extended key and set read-only to true when neutered', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -76,7 +76,7 @@ describe('Wallet -->', () => {
         });
 
         it('take extended key to create wallet and get correct private key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getAccount(wallet);
 
@@ -87,7 +87,7 @@ describe('Wallet -->', () => {
     describe('getAccount() should', () => {
 
         it('throw when wallet initialized with extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -97,7 +97,7 @@ describe('Wallet -->', () => {
         });
 
         it('get catapult compatible private key / public key pair (keypair)', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getAccount(wallet);
 
@@ -109,7 +109,7 @@ describe('Wallet -->', () => {
     describe('getChildAccount() should', () => {
 
         it('throw when wallet initialized with extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
 
@@ -119,7 +119,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive default account when given no path', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getChildAccount(wallet);
 
@@ -128,7 +128,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getChildAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 
@@ -140,7 +140,7 @@ describe('Wallet -->', () => {
     describe('getPublicAccount() should', () => {
 
         it('get catapult compatible read-only account given extended private key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getPublicAccount(wallet);
 
@@ -149,7 +149,7 @@ describe('Wallet -->', () => {
         });
 
         it('get catapult compatible read-only account given extended public key', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const xpub = xkey.getPublicNode();
             const wallet = new Wallet(xpub);
             const account = getPublicAccount(wallet);
@@ -162,7 +162,7 @@ describe('Wallet -->', () => {
     describe('getChildPublicAccount() should', () => {
 
         it('derive default account when given no path', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getChildPublicAccount(wallet);
 
@@ -171,7 +171,7 @@ describe('Wallet -->', () => {
         });
 
         it('derive second account when given path m/44\'/4343\'/1\'/0\'/0\'', () => {
-            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.CATAPULT);
+            const xkey = ExtendedKey.createFromSeed(masterSeed, Network.MIJIN);
             const wallet = new Wallet(xkey);
             const account = getChildPublicAccount(wallet, 'm/44\'/4343\'/1\'/0\'/0\'');
 


### PR DESCRIPTION
Changed:
- ExtendedKey network parameter default values are removed
- Network fields are renamed CATAPULT_PUBLIC -> SYMBOL, CATAPULT -> MIJIN